### PR TITLE
Improve performance

### DIFF
--- a/docs/source/logs.rst
+++ b/docs/source/logs.rst
@@ -16,7 +16,7 @@ The methods generating the most important logs are:
 * ``Engine::run`` for everything related to execution decisions.
 * ``Engine::patch`` for patch generations.
 * ``Engine::instrument`` for instrumentation generations.
-* ``ExecBlockManager::getExecBlock`` for code cache lookup.
+* ``ExecBlockManager::getProgrammedExecBlock`` for code cache lookup.
 * ``ExecBlock::writeSequence`` for JIT code generation.
 * ``ExecBlock::execute`` for sequence execution and callback execution.
 

--- a/include/QBDI/Callback.h
+++ b/include/QBDI/Callback.h
@@ -88,10 +88,10 @@ _QBDI_ENABLE_BITMASK_OPERATORS(VMEvent)
  */
 typedef struct {
     VMEvent event;           /*!< The event which triggered the callback.*/   
-    rword sequenceStart;     /*!< The current sequence start address which can also be the execution transfer destination.*/
-    rword sequenceEnd;       /*!< The current sequence end address which can also be the execution transfer destination.*/
     rword basicBlockStart;   /*!< The current basic block start address which can also be the execution transfer destination.*/
     rword basicBlockEnd;     /*!< The current basic block end address which can also be the execution transfer destination.*/
+    rword sequenceStart;     /*!< The current sequence start address which can also be the execution transfer destination.*/
+    rword sequenceEnd;       /*!< The current sequence end address which can also be the execution transfer destination.*/
     rword lastSignal;        /*!< Not implemented.*/
 } VMState;
 

--- a/src/ExecBlock/ExecBlockManager.h
+++ b/src/ExecBlock/ExecBlockManager.h
@@ -39,14 +39,12 @@ struct InstLoc {
 };
 
 struct SeqLoc {
-    ExecBlock *execBlock;
+    uint16_t blockIdx;
     uint16_t seqID;
-    uint16_t bbIdx;
-};
-
-struct BBInfo {
-    rword start;
-    rword end;
+    rword bbStart;
+    rword bbEnd;
+    rword seqStart;
+    rword seqEnd;
 };
 
 struct ExecRegion {
@@ -54,7 +52,6 @@ struct ExecRegion {
     unsigned                        translated; 
     unsigned                        available;
     std::vector<ExecBlock*>         blocks;
-    std::vector<BBInfo>             bbRegistry;
     std::map<rword, SeqLoc>         sequenceCache;
     std::map<rword, InstLoc>        instCache;
     std::map<rword, InstAnalysis*>  analysisCache;
@@ -80,8 +77,6 @@ private:
 
     size_t findRegion(Range<rword> codeRange);
 
-    SeqLoc getSeqLoc(rword address);
-
     void updateRegionStat(size_t r, rword translated);
 
     float getExpansionRatio() const;
@@ -95,9 +90,9 @@ public:
 
     void printCacheStatistics(FILE* output) const;
 
-    ExecBlock* getExecBlock(rword address);
+    ExecBlock* getProgrammedExecBlock(rword address);
 
-    const BBInfo* getBBInfo(rword address) const;
+    const SeqLoc* getSeqLoc(rword address) const;
 
     void writeBasicBlock(const std::vector<Patch>& basicBlock);
 


### PR DESCRIPTION
Some measurement with earlier versions (< 0.5rc1) of QBDI showed a performance degradation, these commits aim to partially resolve it.

On a benchmark where we only add a BASIC_BLOCK_ENTRY callback to a sample which executes the same basic blocks over and over, the execution time is reduced by 27% (~5.5s -> ~4.0s).
This use case was the worst case scenario where we had the worst performance hit, use cases performing heavy instrumentations should only see a marginal performance increase.

The rest of the performance hit seems to come from the AVX support and the AVX state save and restore during context switches. This is a bit harder to fix and will need more complex design changes.