### PR TITLE
Fix addCodeAddrCB and minor docs modificiations

### DIFF
--- a/docs/source/execblock.rst
+++ b/docs/source/execblock.rst
@@ -19,6 +19,13 @@ addressing load and store. While x86 and x86-64 allow 32 bits offset, ARM only a
 offset [#]_. The ExecBlock design thus only requires to be able to load and store general purpose 
 registers with an address offset up to 4096 bytes.
 
+.. note::
+
+    By default, AVX registers are also saved, one may want to disable this in case where it is not
+    necessary, thus improving perfomances. It can be achieved using the environnement flag 
+    **QBDI_FORCE_DISABLE_AVX**.
+
+
 Some modern operating systems do not allow the allocation of memory pages with read, write and 
 execute permissions (RWX) for security reasons as this greatly facilitates remote code execution 
 exploits. It is thus necessary to allocate two separate pages, with different permissions, for code 

--- a/docs/source/frida_usage.rst
+++ b/docs/source/frida_usage.rst
@@ -88,6 +88,20 @@ with more information is available in Frida/QBDI :ref:`frida-bindins-api` docume
     vm.call(functionPtr, []);
 
 
+If you ever want to pass argument to your callback, this can be done via the **data** argument :
+
+.. code-block:: javascript
+
+    // This callback is used to count the number of basicblocks executed
+    var userData = { counter: 0};
+    var BasicBlockCallback = vm.newVMCallback(function(vm, evt, gpr, fpr, data) {
+        data.counter++;
+        return VMAction.CONTINUE;
+    });
+    vm.addVMEventCB(VMEvent.BASIC_BLOCK_ENTRY, BasicBlockCallback, userData);
+    console.log(userData.counter);
+
+
 Scripts
 +++++++
 

--- a/docs/source/patchdsl.rst
+++ b/docs/source/patchdsl.rst
@@ -389,7 +389,7 @@ Instruction Conditions
 
 .. doxygenfunction:: QBDI::UseReg::UseReg
 
-.. doxygenfunction:: QBDI::AddressInRange::AddressInRange
+.. doxygenfunction:: QBDI::InstructionInRange::InstructionInRange
 
 .. doxygenfunction:: QBDI::OperandIsReg::OperandIsReg
 

--- a/src/Engine/VM.cpp
+++ b/src/Engine/VM.cpp
@@ -225,14 +225,19 @@ uint32_t VM::addCodeCB(InstPosition pos, InstCallback cbk, void *data) {
 
 uint32_t VM::addCodeAddrCB(rword address, InstPosition pos, InstCallback cbk, void *data) {
     RequireAction("VM::addCodeAddrCB", cbk != nullptr, return VMError::INVALID_EVENTID);
-    return addCodeRangeCB(address, address + 1, pos, cbk, data);
+    return addInstrRule(InstrRule(
+        AddressIs(address),
+        getCallbackGenerator(cbk, data),
+        pos,
+        true
+    ));
 }
 
 uint32_t VM::addCodeRangeCB(rword start, rword end, InstPosition pos, InstCallback cbk, void *data) {
     RequireAction("VM::addCodeRangeCB", start < end, return VMError::INVALID_EVENTID);
     RequireAction("VM::addCodeRangeCB", cbk != nullptr, return VMError::INVALID_EVENTID);
     return addInstrRule(InstrRule(
-        AddressInRange(start, end),
+        InstructionInRange(start, end),
         getCallbackGenerator(cbk, data),
         pos,
         true

--- a/src/Patch/PatchCondition.h
+++ b/src/Patch/PatchCondition.h
@@ -127,7 +127,7 @@ public:
     }
 };
 
-class AddressInRange : public PatchCondition, public AutoAlloc<PatchCondition, AddressInRange> {
+class InstructionInRange : public PatchCondition, public AutoAlloc<PatchCondition, InstructionInRange> {
     Range<rword> range;
 
 public:
@@ -137,7 +137,7 @@ public:
      * @param[in] start Start of the range.
      * @param[in] end   End of the range (not included).
     */
-    AddressInRange(Constant start, Constant end) : range(start, end) {};
+    InstructionInRange(Constant start, Constant end) : range(start, end) {};
 
     bool test(const llvm::MCInst* inst, rword address, rword instSize, llvm::MCInstrInfo* MCII) {
         if(range.contains(Range<rword>(address, address + instSize))) {
@@ -153,6 +153,20 @@ public:
         r.add(range);
         return r;
     }
+};
+
+class AddressIs : public PatchCondition, public AutoAlloc<PatchCondition, AddressIs> {
+    rword breakpoint;
+     
+public:
+
+    /*! Return true if on specified address
+    */
+    AddressIs(rword breakpoint) : breakpoint(breakpoint) {};
+    bool test(const llvm::MCInst* inst, rword address, rword instSize, llvm::MCInstrInfo* MCII) {
+        return address == breakpoint;
+    }
+
 };
 
 class OperandIsReg : public PatchCondition, public AutoAlloc<PatchCondition, OperandIsReg> {


### PR DESCRIPTION
addCodeAddrCB was not working properly most of the time, due to the way we were checking if the address was in the instrumented range. I propose a fix that seems to solve the issue, I also added a test for it since we were not using it in any of our tests.
(I also added missing stuff in our documentation).