### PR TITLE
Document getCurrentProcessMaps (#36); improve pyQBDI documentation

### DIFF
--- a/docs/pyqbdi.py
+++ b/docs/pyqbdi.py
@@ -5,28 +5,28 @@ class vm():
     def getGPRState():
         """Obtain the current general purpose register state.
 
-            :returns: GPRState  (a structure containing the GPR state).
+            :returns: GPRState  (an object containing the GPR state).
         """
         pass
 
     def getFPRState():
         """Obtain the current floating point register state.
 
-            :returns: FPRState  (a structure containing the FPR state).
+            :returns: FPRState  (an object containing the FPR state).
         """
         pass
 
     def setGPRState(gprState):
         """Set the general purpose register state.
 
-            :param grpState: A structure containing the GPR state.
+            :param grpState: An object containing the GPR state.
         """
         pass
 
     def setFPRState(fprState):
         """Set the current floating point register state.
 
-            :param fprState: A structure containing the FPR state
+            :param fprState: An object containing the FPR state
         """
         pass
 
@@ -54,7 +54,7 @@ class vm():
         """Register a callback event for a specific instruction event.
 
             :param pos: Relative position of the event callback (:py:const:`pyqbdi.PREINST` / :py:const:`pyqbdi.POSTINST`).
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns: The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -66,7 +66,7 @@ class vm():
 
             :param address: Code address which will trigger the callback.
             :param pos: Relative position of the event callback (:py:const:`pyqbdi.PREINST` / :py:const:`pyqbdi.POSTINST`).
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns: The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -79,7 +79,7 @@ class vm():
             :param start: Start of the address range which will trigger the callback.
             :param end: End of the address range which will trigger the callback.
             :param pos: Relative position of the event callback (:py:const:`pyqbdi.PREINST` / :py:const:`pyqbdi.POSTINST`).
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns: The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -91,7 +91,7 @@ class vm():
 
             :param mnemonic: Mnemonic to match.
             :param pos: Relative position of the event callback (:py:const:`pyqbdi.PREINST` / :py:const:`pyqbdi.POSTINST`).
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns: The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -117,7 +117,7 @@ class vm():
 
             :param address: Code address which will trigger the callback.
             :param type: A mode bitfield: either :py:const:`pyqbdi.MEMORY_READ`, :py:const:`pyqbdi.MEMORY_WRITE` or both (:py:const:`pyqbdi.MEMORY_READ_WRITE`).
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns:  The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -130,7 +130,7 @@ class vm():
             :param start: Start of the address range which will trigger the callback.
             :param end: End of the address range which will trigger the callback.
             :param type: A mode bitfield: either :py:const:`pyqbdi.MEMORY_READ`, :py:const:`pyqbdi.MEMORY_WRITE` or both (:py:const:`pyqbdi.MEMORY_READ_WRITE`).
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns:  The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -141,7 +141,7 @@ class vm():
         """Register a callback event for every memory access matching the type bitfield made by an instruction.
 
             :param type: A mode bitfield: either :py:const:`pyqbdi.MEMORY_READ`, :py:const:`pyqbdi.MEMORY_WRITE` or both (:py:const:`pyqbdi.MEMORY_READ_WRITE`).
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns: The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -158,25 +158,25 @@ class vm():
         pass
 
     def getInstAnalysis(type):
-        """ Obtain the analysis of an instruction metadata. Analysis results are cached in the VM. The validity of the returned pointer is only guaranteed until the end of the callback, else  a deepcopy of the structure is required.
+        """ Obtain the analysis of an instruction metadata. Analysis results are cached in the VM. The validity of the returned object is only guaranteed until the end of the callback, else a deepcopy of the object is required.
 
-            :param type: Properties to retrieve during analysis.
+            :param type: Properties to retrieve during analysis (pyqbdi.ANALYSIS_INSTRUCTION, pyqbdi.ANALYSIS_DISASSEMBLY, pyqbdi.ANALYSIS_OPERANDS, pyqbdi.ANALYSIS_SYMBOL).
 
-            :returns: A InstAnalysis structure containing the analysis result.
+            :returns: A :py:class:`InstAnalysis` object containing the analysis result.
         """
         pass
 
     def getInstMemoryAccess():
         """Obtain the memory accesses made by the last executed instruction.
 
-            :returns: An array of memory accesses made by the instruction.
+            :returns: A list of memory accesses (:py:class:`MemoryAccess`) made by the instruction.
         """
         pass
 
     def getBBMemoryAccess():
         """Obtain the memory accesses made by the last executed basic block.
 
-            :returns: An array of memory accesses made by the basic block.
+            :returns: A list of memory accesses (:py:class:`MemoryAccess`) made by the basic block.
         """
         pass
 
@@ -206,7 +206,7 @@ class vm():
         """Register a callback event for a specific VM event.
 
             :param mask: A mask of VM event type which will trigger the callback.
-            :param cbk: A function pointer to the callback.
+            :param cbk: A function to be called back.
             :param data: User defined data passed to the callback.
 
             :returns: The id of the registered instrumentation (or :py:const:`pyqbdi.INVALID_EVENTID` in case of failure).
@@ -286,7 +286,7 @@ def alignedAlloc(size, align):
         :param size: Allocation size in bytes.
         :param align: Base address alignement in bytes.
 
-        :returns: Pointer to the allocated memory or NULL in case an error was encountered.
+        :returns: Pointer to the allocated memory (as a long) or NULL in case an error was encountered.
     """
     pass
 
@@ -323,6 +323,14 @@ def getModuleNames():
     """ Get a list of all the module names loaded in the process memory.
 
         :returns: A list of strings, each one containing the name of a loaded module.
+    """
+    pass
+
+
+def getCurrentProcessMaps():
+    """ Get a list of all the memory maps (regions) of the current process.
+
+        :returns: A list of :py:class:`MemoryMap` object.
     """
     pass
 
@@ -372,21 +380,111 @@ def encodeFloat(val):
 
 
 # Various objects
-InstAnalysis = None
-""" InstAnalysis object, a binding to :cpp:type:`QBDI::InstAnalysis`
-"""
+class MemoryMap:
+    """ Map of a memory area (region).
+    """
+    range = (0, 0xffff)
+    """ A range of memory (region), delimited between a start and an (excluded) end address. """
+    permission = 0
+    """ Region access rights (PF_READ, PF_WRITE, PF_EXEC). """
+    name = ""
+    """ Region name (useful when a region is mapping a module). """
+
+
+class InstAnalysis:
+    """ Object containing analysis results of an instruction provided by the VM.
+    """
+    mnemonic = ""
+    """ LLVM mnemonic (warning: None if !ANALYSIS_INSTRUCTION) """
+    address = 0
+    """ Instruction address """
+    instSize = 0
+    """ Instruction size (in bytes) """
+    affectControlFlow = False
+    """ true if instruction affects control flow """
+    isBranch = False
+    """ true if instruction acts like a 'jump' """
+    isCall = False
+    """ true if instruction acts like a 'call' """
+    isReturn = False
+    """ true if instruction acts like a 'return' """
+    isCompare = False
+    """ true if instruction is a comparison """
+    isPredicable = False
+    """ true if instruction contains a predicate (~is conditional) """
+    mayLoad = False
+    """ true if instruction 'may' load data from memory """
+    mayStore = False
+    """ true if instruction 'may' store data to memory """
+    disassembly = ""
+    """ Instruction disassembly (warning: None if !ANALYSIS_DISASSEMBLY) """
+    numOperands = 0
+    """ Number of operands used by the instruction """
+    operands = []
+    """ A list of :py:class:`OperandAnalysis` objects.
+        (warning: empty if !ANALYSIS_OPERANDS) """
+    symbol = ""
+    """ Instruction symbol (warning: None if !ANALYSIS_SYMBOL or not found) """
+    symbolOffset = 0
+    """ Instruction symbol offset """
+    module = ""
+    """ Instruction module name (warning: None if !ANALYSIS_SYMBOL or not found) """
+
+
+class OperandAnalysis:
+    """ Object containing analysis results of an operand provided by the VM.
+    """
+    # Common fields
+    type = 0
+    """ Operand type (pyqbdi.OPERAND_IMM, pyqbdi.OPERAND_REG, pyqbdi.OPERAND_PRED) """
+    value = 0
+    """ Operand value (if immediate), or register Id """
+    size = 0
+    """ Operand size (in bytes) """
+    # Register specific fields
+    regOff = 0
+    """ Sub-register offset in register (in bits) """
+    regCtxIdx = 0
+    """ Register index in VM state """
+    regName = ""
+    """ Register name """
+    regAccess = 0
+    """ Register access type (pyqbdi.REGISTER_READ, pyqbdi.REGISTER_WRITE, pyqbdi.REGISTER_READ_WRITE) """
+
+
+class VMState:
+    """ Object describing the current VM state.
+    """
+    event = 0
+    """ The event(s) which triggered the callback (must be checked using a mask: event & pyqbdi.BASIC_BLOCK_ENTRY). """
+    basicBlockStart = 0
+    """ The current basic block start address which can also be the execution transfer destination. """
+    basicBlockEnd = 0
+    """ The current basic block end address which can also be the execution transfer destination. """
+    sequenceStart = 0
+    """ The current sequence start address which can also be the execution transfer destination. """
+    sequenceEnd = 0
+    """ The current sequence end address which can also be the execution transfer destination. """
+
+
+class MemoryAccess:
+    """ Describe a memory access
+    """
+    instAddress = 0
+    """ Address of instruction making the access. """
+    accessAddress = 0
+    """ Address of accessed memory. """
+    value = 0
+    """ Value read from / written to memory. """
+    size = 0
+    """ Size of memory access (in bytes). """
+    type = 0
+    """ Memory access type (pyqbdi.MEMORY_READ, pyqbdi.MEMORY_WRITE, pyqbdi.MEMORY_READ_WRITE). """
+
+
 GPRState = None
 """ GPRState object, a binding to :cpp:type:`QBDI::GPRState`
 """
 FPRState = None
 """ FPRState object, a binding to :cpp:type:`QBDI::FPRState`
-"""
-MemoryAccess = None
-""" MemoryAccess object, a binding to :cpp:type:`QBDI::MemoryAccess`
-"""
-OperandAnalysis = None
-""" OperandAnalysis object, a binding to :cpp:type:`QBDI::OperandAnalysis`
-"""
-VMState = None
-""" VMState object, a binding to :cpp:type:`QBDI::VMState`
 """

--- a/docs/requirements.readthedocs.txt
+++ b/docs/requirements.readthedocs.txt
@@ -1,3 +1,3 @@
-Sphinx>=1.2.0
-breathe>=4.0.0
+Sphinx==1.6.7
+breathe==4.7.3
 -e git+https://github.com/lunant/sphinxcontrib-autojs.git#egg=sphinxcontrib-autojs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+requirements.readthedocs.txt

--- a/docs/source/api_c.rst
+++ b/docs/source/api_c.rst
@@ -245,13 +245,13 @@ increment an integer passed as a pointer through the data parameter::
    } 
 
 The return value of this function is very important to determine how the VM should handle the 
-resuming of execution. :cpp:enum:`QBDI_CONTINUE` will directly switch back to the 
+resuming of execution. :cpp:enumerator:`QBDI_CONTINUE` will directly switch back to the 
 guest code in the current ExecBlock without further processing by the VM. This means that 
 modification of the Program Counter will not be taken into account and modifications of the program 
 code will only be effective after the end of the current basic block (provided the code cache is 
 cleared, which is not currently exported via the API). One can force those changes to be taken into 
 account by breaking from the ExecBlock execution and returning early inside the VM using the 
-:cpp:enum:`QBDI_BREAK_TO_VM`. :cpp:enum:`QBDI_STOP` causes the VM to stop the execution and the 
+:cpp:enumerator:`QBDI_BREAK_TO_VM`. :cpp:enumerator:`QBDI_STOP` causes the VM to stop the execution and the 
 :c:func:`qbdi_run` to return.
 
 The :c:func:`qbdi_addCodeCB` function allows to add a callback on every instruction (inside the
@@ -311,9 +311,9 @@ to log the memory writes.
 
 The type parameter allows to filter the callback on specific memory access type:
 
-* :cpp:enum:`QBDI_MEMORY_READ` triggers the callback **before** every instruction performing a memory read.
-* :cpp:enum:`QBDI_MEMORY_WRITE` triggers the callback **after** every instruction performing a memory write.
-* :cpp:enum:`QBDI_MEMORY_READ_WRITE` triggers the callback **after** every instruction performing a memory read and/or write.
+* :cpp:enumerator:`QBDI_MEMORY_READ` triggers the callback **before** every instruction performing a memory read.
+* :cpp:enumerator:`QBDI_MEMORY_WRITE` triggers the callback **after** every instruction performing a memory write.
+* :cpp:enumerator:`QBDI_MEMORY_READ_WRITE` triggers the callback **after** every instruction performing a memory read and/or write.
 
 .. doxygenfunction:: qbdi_addMemAccessCB
    :project: QBDI_C
@@ -445,14 +445,14 @@ callbacks.
 .. doxygenfunction:: qbdi_recordMemoryAccess
    :project: QBDI_C
 
-The memory access type always refers to either :cpp:enum:`QBDI_MEMORY_READ`, :cpp:enum:`QBDI_MEMORY_WRITE`, 
-:cpp:enum:`QBDI_MEMORY_READ_WRITE` (which is a bitfield combination of the two previous ones).
+The memory access type always refers to either :cpp:enumerator:`QBDI_MEMORY_READ`, :cpp:enumerator:`QBDI_MEMORY_WRITE`, 
+:cpp:enumerator:`QBDI_MEMORY_READ_WRITE` (which is a bitfield combination of the two previous ones).
 
 Once the logging has been enabled, :c:func:`qbdi_getInstMemoryAccess` and 
 :c:func:`qbdi_getBBMemoryAccess` can be used to retrieve the memory accesses made by the 
 last instruction or by the last basic block. These two APIs return :c:func:`qbdi_MemoryAccess` 
 structures. Write memory accesses are only returned if the instruction has already been executed 
-(i.e. in the case of a :cpp:enum:`QBDI_POSTINST`). The :ref:`cryptolock-c` example 
+(i.e. in the case of a :cpp:enumerator:`QBDI_POSTINST`). The :ref:`cryptolock-c` example 
 shows how to use those APIs to log the memory writes.
 
 

--- a/docs/source/api_cpp.rst
+++ b/docs/source/api_cpp.rst
@@ -6,14 +6,14 @@ VM C++
 Initialization
 --------------
 
-The :cpp:member:`QBDI::VM::VM` constructor is used to create a new VM instance, using host
+The :cpp:func:`QBDI::VM::VM` constructor is used to create a new VM instance, using host
 CPU as a reference::
 
     QBDI::VM *vm = new QBDI::VM();
 
 .. doxygenfunction:: QBDI::VM::VM
 
-The :cpp:member:`QBDI::VM::VM` constructor can also take two optional parameters used to specify 
+The :cpp:func:`QBDI::VM::VM` constructor can also take two optional parameters used to specify 
 the CPU type or architecture and additional attributes of the CPU. Those are the same used by LLVM. 
 Here's how you would initialize a VM for an ARM Cortex-A9 supporting the VFP2 floating point 
 instructions::
@@ -26,16 +26,16 @@ State Management
 The state of the guest processor can be queried and modified using two architectures dependent structures :cpp:class:`GPRState` and :cpp:class:`FPRState` which are detailed below for each architecture 
 (:ref:`cpp-state-x86-64` and :ref:`cpp-state-arm`).
 
-The :cpp:member:`QBDI::VM::getGPRState` and :cpp:member:`QBDI::VM::getFPRState` allow to 
-query the current state of the guest processor while the :cpp:member:`QBDI::VM::setGPRState` 
-and :cpp:member:`QBDI::VM::setFPRState` allow to modify it::
+The :cpp:func:`QBDI::VM::getGPRState` and :cpp:func:`QBDI::VM::getFPRState` allow to 
+query the current state of the guest processor while the :cpp:func:`QBDI::VM::setGPRState` 
+and :cpp:func:`QBDI::VM::setFPRState` allow to modify it::
 
    QBDI::GPRState gprState; // local GPRState structure
    gprState = *(vm->getGPRState()); // Copy the vm structure into our local structure
    gprState.rax = (QBDI::rword) 42; // Set the value of the RAX register
    vm->setGPRState(&gprState); // Copy our local structure to the vm structure
 
-As :cpp:member:`QBDI::VM::getGPRState` and :cpp:member:`QBDI::VM::getFPRState` return 
+As :cpp:func:`QBDI::VM::getGPRState` and :cpp:func:`QBDI::VM::getFPRState` return 
 pointers to the VM context, it is possible to use them to modify the GPR and FPR states 
 directly. The code below is equivalent to the example from above but avoid unnecessary copies::
 
@@ -116,19 +116,19 @@ Execution
 Starting a Run
 ^^^^^^^^^^^^^^
 
-The :cpp:member:`QBDI::VM::run` method is used to start the execution of a piece of code by the 
+The :cpp:func:`QBDI::VM::run` method is used to start the execution of a piece of code by the 
 DBI. It first sets the Program Counter of the VM CPU state to the start parameter then runs the 
 code through the DBI until a control flow instruction branches on the stop parameter. See the 
-:ref:`fibonacci-cpp` example for a basic usage of QBDI and the :cpp:member:`QBDI::VM::run` 
+:ref:`fibonacci-cpp` example for a basic usage of QBDI and the :cpp:func:`QBDI::VM::run` 
 method.
 
 .. doxygenfunction:: QBDI::VM::run
 
-:cpp:member:`QBDI::VM::run` is a low level method which implies that the :cpp:class:`QBDI::GPRState`
+:cpp:func:`QBDI::VM::run` is a low level method which implies that the :cpp:class:`QBDI::GPRState`
 has been properly initialized before.
 
 But a very common usage of QBDI is to start instrumentation on a function call.
-The :cpp:member:`QBDI::VM::call` is a helper method which behaves like a function call.
+The :cpp:func:`QBDI::VM::call` is a helper method which behaves like a function call.
 It takes a function pointer, a list of arguments, and return the call's result.
 The only requirement is a valid (and properly aligned) stack pointer.
 In most cases, using :cpp:func:`QBDI::allocateVirtualStack` is enough, as a call
@@ -151,12 +151,12 @@ out of the set of instrumented ranges nor guaranteed to actually catch the retur
 set of instrumented ranges.
 
 .. warning::
-   By default the set of instrumented ranges is empty, a call to :cpp:member:`QBDI::VM::run` 
+   By default the set of instrumented ranges is empty, a call to :cpp:func:`QBDI::VM::run` 
    will thus very quickly escape from the instrumentation process through an execution transfer 
    made by the :cpp:class:`QBDI::ExecBroker`.
 
 The basic methods to manipulate this set of instrumented ranges are 
-:cpp:member:`QBDI::VM::addInstrumentedRange` and :cpp:member:`QBDI::VM::removeInstrumentedRange`.
+:cpp:func:`QBDI::VM::addInstrumentedRange` and :cpp:func:`QBDI::VM::removeInstrumentedRange`.
 
 .. doxygenfunction:: QBDI::VM::addInstrumentedRange
    :project: QBDI_CPP
@@ -166,27 +166,42 @@ The basic methods to manipulate this set of instrumented ranges are
    :project: QBDI_CPP
 
 As manipulating address ranges can be problematic, helpers API allow to use process memory maps 
-information. The :cpp:member:`QBDI::VM::addInstrumentedModule` and 
-:cpp:member:`QBDI::VM::removeInstrumentedModule` allow to use executable module names instead 
+information. The :cpp:func:`QBDI::VM::addInstrumentedModule` and 
+:cpp:func:`QBDI::VM::removeInstrumentedModule` allow to use executable module names instead 
 of address ranges. The currently loaded module names can be queried using 
-:cpp:func:`QBDI::getModuleNames`. The :cpp:member:`QBDI::VM::addInstrumentedModuleFromAddr`
-and :cpp:member:`QBDI::VM::removeInstrumentedModuleFromAddr` methods allow to use any known
+:cpp:func:`QBDI::getModuleNames`. The :cpp:func:`QBDI::VM::addInstrumentedModuleFromAddr`
+and :cpp:func:`QBDI::VM::removeInstrumentedModuleFromAddr` methods allow to use any known
 address from a module to instrument it.
 
-The :cpp:member:`QBDI::VM::instrumentAllExecutableMaps` allows to instrument every memory map 
+The :cpp:func:`QBDI::VM::instrumentAllExecutableMaps` allows to instrument every memory map 
 which is executable, the undesired address range can later be removed using the previous APIs in a 
 blacklist approach. This approach is demonstrated in the :ref:`thedude-cpp` example where 
 sub-functions are removed in function of a trace level supplied as argument.
 
-The :cpp:member:`QBDI::VM::removeAllInstrumentedRanges` can be used to remove **all** ranges recorded
+The :cpp:func:`QBDI::VM::removeAllInstrumentedRanges` can be used to remove **all** ranges recorded
 through previous APIs (after this call, the VM will have no range left to instrument).
 
-Below is an example of how to obtain, iterate then destroy the module names using the API.
+Below is an example of how to obtain, iterate then print the module names using the API.
 
 .. include:: ../../examples/modules.cpp
    :code:
 
+.. doxygenclass:: QBDI::MemoryMap
+   :project: QBDI_CPP
+   :members:
+
+.. doxygenenum:: QBDI::Permission
+   :project: QBDI_CPP
+
+.. doxygenclass:: QBDI::Range
+   :project: QBDI_CPP
+   :members:
+
+.. doxygenfunction:: QBDI::getCurrentProcessMaps
+   :project: QBDI_CPP
+
 .. doxygenfunction:: QBDI::getModuleNames
+   :project: QBDI_CPP
 
 .. doxygenfunction:: QBDI::VM::addInstrumentedModule
 
@@ -237,7 +252,7 @@ cleared, which is not currently exported via the API). One can force those chang
 account by breaking from the ExecBlock execution and returning early inside the VM using the 
 :cpp:enumerator:`BREAK_TO_VM`. :cpp:enumerator:`STOP` is not yet implemented.
 
-The :cpp:member:`QBDI::VM::addCodeCB` method allows to add a callback on every instruction (inside the
+The :cpp:func:`QBDI::VM::addCodeCB` method allows to add a callback on every instruction (inside the
 instrumented range).
 If we register the previous callback to be called before every instruction, we effectively get
 an instruction counting instrumentation::
@@ -257,8 +272,8 @@ an instruction counting instrumentation::
 .. doxygenfunction:: QBDI::VM::addCodeCB
 
 It is also possible to register an :cpp:type:`QBDI::InstCallback` for a specific instruction 
-address or address range with the :cpp:member:`QBDI::VM::addCodeAddrCB` and 
-:cpp:member:`QBDI::VM::addCodeRangeCB` methods. These allow to fine-tune the instrumentation to 
+address or address range with the :cpp:func:`QBDI::VM::addCodeAddrCB` and 
+:cpp:func:`QBDI::VM::addCodeRangeCB` methods. These allow to fine-tune the instrumentation to 
 specific codes or portions of them.
 
 .. doxygenfunction:: QBDI::VM::addCodeAddrCB
@@ -280,9 +295,9 @@ Memory Callback
 
 The memory callbacks (currently only supported under X86_64) allow to trigger callbacks on specific 
 memory events. They use the same callback prototype, :cpp:type:`QBDI::InstCallback`, than 
-instruction callback. They can be registered using the :cpp:member:`QBDI::VM::addMemAccessCB` API.
+instruction callback. They can be registered using the :cpp:func:`QBDI::VM::addMemAccessCB` API.
 The API takes care of enabling the corresponding inline memory access logging instrumentation using 
-:cpp:member:`QBDI::VM::recordMemoryAccess`. The memory accesses themselves are not directly provided 
+:cpp:func:`QBDI::VM::recordMemoryAccess`. The memory accesses themselves are not directly provided 
 as a callback parameter and need to be retrieved using the memory access APIs (see 
 :ref:`memory-access-analysis-cpp`). The :ref:`cryptolock-cpp` example shows how to use those APIs 
 to log the memory writes.
@@ -290,19 +305,19 @@ to log the memory writes.
 
 The type parameter allows to filter the callback on specific memory access type:
 
-* :cpp:var:`QBDI::MEMORY_READ` triggers the callback **before** every instruction performing a memory read.
-* :cpp:var:`QBDI::MEMORY_WRITE` triggers the callback **after** every instruction performing a memory write.
-* :cpp:var:`QBDI::MEMORY_READ_WRITE` triggers the callback **after** every instruction performing a memory read and/or write.
+* :cpp:enumerator:`QBDI::MEMORY_READ` triggers the callback **before** every instruction performing a memory read.
+* :cpp:enumerator:`QBDI::MEMORY_WRITE` triggers the callback **after** every instruction performing a memory write.
+* :cpp:enumerator:`QBDI::MEMORY_READ_WRITE` triggers the callback **after** every instruction performing a memory read and/or write.
 
 .. doxygenfunction:: QBDI::VM::addMemAccessCB
 
-To enable more flexibility on the callback filtering, :cpp:member:`QBDI::VM::addMemAddrCB` and 
-:cpp:member:`QBDI::VM::addMemRangeCB` allow to filter for memory accesses targeting a specific 
+To enable more flexibility on the callback filtering, :cpp:func:`QBDI::VM::addMemAddrCB` and 
+:cpp:func:`QBDI::VM::addMemRangeCB` allow to filter for memory accesses targeting a specific 
 memory address or range. However those callbacks are virtual callbacks: they cannot be directly 
 triggered by the instrumentation because the access address needs to be checked dynamically but 
 are instead triggered by a gate callback which takes care of the dynamic access address check and 
 forwards or not the event to the virtual callback. This system thus has the same overhead as 
-:cpp:member:`QBDI::VM::addMemAccessCB` and is only meant as an API helper.
+:cpp:func:`QBDI::VM::addMemAccessCB` and is only meant as an API helper.
 
 .. doxygenfunction:: QBDI::VM::addMemAddrCB
 
@@ -343,8 +358,8 @@ Removing Instrumentations
 
 Several callbacks can be registered for the same event and will run in the order they were added.
 The id returned by this method can be used to modify the callback afterward. The 
-:cpp:member:`QBDI::VM::deleteInstrumentation` method allows to remove an instrumentation by id 
-while the :cpp:member:`QBDI::VM::deleteAllInstrumentations` method will remove all 
+:cpp:func:`QBDI::VM::deleteInstrumentation` method allows to remove an instrumentation by id 
+while the :cpp:func:`QBDI::VM::deleteAllInstrumentations` method will remove all 
 instrumentations. This code would do two different executions with different callbacks::
 
    uint32_t cb1 = vm->addCodeCB(QBDI::InstPosition::PREINST, Callback1, &some_data);
@@ -393,7 +408,7 @@ and is amortized using a cache inside the VM.
    :undoc-members:
 
 If provided :cpp:type:`QBDI::AnalysisType` is equal to `QBDI::ANALYSIS_OPERANDS`, then
-:cpp:member:`QBDI::getInstAnalysis` will also analyze all instruction operands, and
+:cpp:func:`QBDI::getInstAnalysis` will also analyze all instruction operands, and
 fill an array of :cpp:type:`QBDI::OperandAnalysis` (of length `numOperands`).
 
 .. doxygenstruct:: QBDI::OperandAnalysis
@@ -413,18 +428,18 @@ Memory Access Analysis
 
 QBDI VM can log memory access using inline instrumentation. This adds instrumentation rules 
 which store the accessed addresses and values into specific memory variables called 
-*instruction shadows*. To enable this memory logging, the :cpp:member:`QBDI::VM::recordMemoryAccess` 
+*instruction shadows*. To enable this memory logging, the :cpp:func:`QBDI::VM::recordMemoryAccess` 
 API can be used. This memory logging is also automatically enabled when calling one of the memory 
 callbacks.
 
 .. doxygenfunction:: QBDI::VM::recordMemoryAccess
 
-The memory access type always refers to either :cpp:var:`QBDI::MEMORY_READ`, 
-:cpp:var:`QBDI::MEMORY_WRITE`, :cpp:var:`QBDI::MEMORY_READ_WRITE` (which is a bit field combination 
+The memory access type always refers to either :cpp:enumerator:`QBDI::MEMORY_READ`, 
+:cpp:enumerator:`QBDI::MEMORY_WRITE`, :cpp:enumerator:`QBDI::MEMORY_READ_WRITE` (which is a bit field combination 
 of the two previous ones).
 
-Once the logging has been enabled, :cpp:member:`QBDI::VM::getInstMemoryAccess` and 
-:cpp:member:`QBDI::VM::getBBMemoryAccess` can be used to retrieve the memory accesses made by the 
+Once the logging has been enabled, :cpp:func:`QBDI::VM::getInstMemoryAccess` and 
+:cpp:func:`QBDI::VM::getBBMemoryAccess` can be used to retrieve the memory accesses made by the 
 last instruction or by the last basic block. These two APIs return :cpp:class:`QBDI::MemoryAccess` 
 structures. Write memory accesses are only returned if the instruction has already been executed 
 (i.e. in the case of a :cpp:enumerator:`QBDI::InstPosition::POSTINST`). The :ref:`cryptolock-cpp` 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -129,7 +129,7 @@ exclude_patterns = []
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
@@ -338,3 +338,5 @@ breathe_projects = {
 breathe_domain_by_file_pattern = {
     "include/VM_C.h" : "c",
 }
+
+breathe_use_project_refids = True

--- a/docs/source/pyQBDI_bindings.rst
+++ b/docs/source/pyQBDI_bindings.rst
@@ -46,7 +46,7 @@ Instrumentation
              removeInstrumentedModule, removeInstrumentedModuleFromAddr
 
 .. automodule:: pyqbdi
-   :members: getModuleNames
+   :members: getModuleNames, getCurrentProcessMaps
 
 
 Memory Callback
@@ -88,14 +88,21 @@ Helpers
 Objects
 ^^^^^^^
 
-.. autodata:: pyqbdi.InstAnalysis
+.. autoclass:: pyqbdi.MemoryMap
+    :members:
+
+.. autoclass:: pyqbdi.InstAnalysis
+    :members:
+
+.. autoclass:: pyqbdi.OperandAnalysis
+    :members:
+
+.. autoclass:: pyqbdi.VMState
+    :members:
+
+.. autoclass:: pyqbdi.MemoryAccess
+    :members:
 
 .. autodata:: pyqbdi.GPRState
 
 .. autodata:: pyqbdi.FPRState
-
-.. autodata:: pyqbdi.MemoryAccess
-
-.. autodata:: pyqbdi.OperandAnalysis
-
-.. autodata:: pyqbdi.VMState

--- a/include/QBDI/InstAnalysis.h
+++ b/include/QBDI/InstAnalysis.h
@@ -86,8 +86,8 @@ typedef struct {
     bool        isPredicable;       /*!< true if instruction contains a predicate (~is conditional) */
     bool        mayLoad;            /*!< true if instruction 'may' load data from memory */
     bool        mayStore;           /*!< true if instruction 'may' store data to memory */
-    // ANALISYS_DISASSEMBLY
-    char*       disassembly;        /*!< Instruction disassembly (warning: NULL if !ANALISYS_DISASSEMBLY) */
+    // ANALYSIS_DISASSEMBLY
+    char*       disassembly;        /*!< Instruction disassembly (warning: NULL if !ANALYSIS_DISASSEMBLY) */
     // ANALYSIS_OPERANDS
     uint8_t     numOperands;        /*!< Number of operands used by the instruction */
     OperandAnalysis* operands;      /*!< Structure containing analysis results of an operand provided by the VM.

--- a/include/QBDI/Memory.h
+++ b/include/QBDI/Memory.h
@@ -34,31 +34,44 @@
 
 namespace QBDI {
 
+/*! Memory access rights.
+ */
 typedef enum {
-    PF_NONE = 0,
-    PF_READ = 1,
-    PF_WRITE = 2,
-    PF_EXEC = 4
+    _QBDI_EI(PF_NONE) = 0,   /*!< No access */
+    _QBDI_EI(PF_READ) = 1,   /*!< Read access */
+    _QBDI_EI(PF_WRITE) = 2,  /*!< Write access */
+    _QBDI_EI(PF_EXEC) = 4    /*!< Execution access */
 } Permission;
 
 _QBDI_ENABLE_BITMASK_OPERATORS(Permission)
 
+/*! Map of a memory area (region).
+ */
 class MemoryMap {
 
 public:
 
-    Range<rword> range;
-    Permission   permission;
-    std::string  name;
+    Range<rword> range;       /*!< A range of memory (region), delimited between a start and an (excluded) end address. */
+    Permission   permission;  /*!< Region access rights (PF_READ, PF_WRITE, PF_EXEC). */
+    std::string  name;        /*!< Region name (useful when a region is mapping a module). */
 
+    /* Construct a new (empty) MemoryMap.
+     */
     MemoryMap() : range(0, 0), permission(QBDI::PF_NONE), name("") {};
 
-    MemoryMap(Range<rword> range, Permission permission, std::string name) : 
+    /*! Construct a new MemoryMap (given some properties).
+     *
+     * @param[in] range        A range of memory (region), delimited between
+     *                         a start and an (excluded) end address.
+     * @param[in] permission   Region access rights (PF_READ, PF_WRITE, PF_EXEC).
+     * @param[in] name         Region name (useful when a region is mapping a module).
+     */
+   MemoryMap(Range<rword> range, Permission permission, std::string name) :
         range(range), permission(permission), name(name) {}
 
 };
 
-/*! Get a list of all the memory maps of a process.
+/*! Get a list of all the memory maps (regions) of a process.
  *
  * @param[in] pid The identifier of the process.
  *
@@ -66,7 +79,7 @@ public:
  */
 QBDI_EXPORT std::vector<MemoryMap> getRemoteProcessMaps(QBDI::rword pid);
 
-/*! Get a list of all the memory maps of the current process.
+/*! Get a list of all the memory maps (regions) of the current process.
  *
  * @return  A vector of MemoryMap object.
  */

--- a/include/QBDI/Range.h
+++ b/include/QBDI/Range.h
@@ -36,9 +36,13 @@ private:
 
 public:
 
-    T start;
-    T end;
+    T start;  /*!< Range start value. */
+    T end;    /*!< Range end value (always excluded). */
 
+    /*! Construct a new range.
+     * @param[in] start  Range start value.
+     * @param[in] end  Range end value (excluded).
+     */
     Range(T start, T end) {
         if(start < end) {
             this->start = start;
@@ -49,32 +53,68 @@ public:
         }
     }
 
+    /*! Return the total length of a range.
+     */
     T size() const {
         return end - start;
     }
 
+    /*! Return True if two ranges are equal (same boundaries).
+     *
+     * @param[in] r  Range to check.
+     *
+     * @return  True if equal.
+     */
     bool operator == (const Range& r) const {
         return r.start == start && r.end == end;
     }
 
+    /*! Return True if an value is inside current range boundaries.
+     *
+     * @param[in] t  Value to check.
+     *
+     * @return  True if contained.
+     */
     bool contains(T t) const {
         return (start <= t) && (t < end);
     }
 
+    /*! Return True if a range is inside current range boundaries.
+     *
+     * @param[in] r  Range to check.
+     *
+     * @return  True if contained.
+     */
     bool contains(Range<T> r) const {
         return (start <= r.start) && (r.end <= end);
     }
 
+    /*! Return True if a range is overlapping current range lower or/and upper boundary.
+     *
+     * @param[in] r  Range to check.
+     *
+     * @return  True if overlapping.
+     */
     bool overlaps(Range<T> r) const {
         return r.contains(*this) || this->contains(r) ||
                ((start <= r.start) && (r.start < end)) || 
                ((start < r.end) && (r.end <= end));
     }
 
+    /*! Pretty print a range
+     *
+     * @param[in] os  An output stream.
+     */
     void display(std::ostream &os) const {
         os << "(0x" << std::hex << start << ", 0x" << end << ")";
     }
 
+    /*! Return the intersection of two ranges.
+     *
+     * @param[in] r  Range to intersect with current range.
+     *
+     * @return  A new range.
+     */
     Range<T> intersect(Range<T> r) const {
         return Range<T>(max(start, r.start), min(end, r.end));
     }

--- a/tools/pyqbdi/pyqbdi.cpp
+++ b/tools/pyqbdi/pyqbdi.cpp
@@ -3174,9 +3174,9 @@ namespace QBDI {
       }
 
 
-      /*! Get a list of all the modules loaded in the process memory.
+      /*! Get a list of all the memory maps (regions) of the current process.
        *
-       * @return  A list of MemoryMap, each one containing the metadata of a loaded module.
+       * @return  A list of MemoryMap, each one containing the metadata of a region.
        */
       static PyObject* pyqbdi_getCurrentProcessMaps(PyObject* self, PyObject* noarg) {
         PyObject* ret  = nullptr;
@@ -3323,7 +3323,7 @@ namespace QBDI {
         {"decodeFloat",          (PyCFunction)pyqbdi_decodeFloat,          METH_O,        "Decode a float encoded as a long."},
         {"encodeFloat",          (PyCFunction)pyqbdi_encodeFloat,          METH_O,        "Encode a float as a long."},
         {"getModuleNames",       (PyCFunction)pyqbdi_getModuleNames,       METH_NOARGS,   "Get a list of all the module names loaded in the process memory."},
-        {"getCurrentProcessMaps",(PyCFunction)pyqbdi_getCurrentProcessMaps,METH_NOARGS,   "Get a list of all the modules loaded in the process memory."},
+        {"getCurrentProcessMaps",(PyCFunction)pyqbdi_getCurrentProcessMaps,METH_NOARGS,   "Get a list of all the memory maps (regions) of the current process."},
         {"readMemory",           (PyCFunction)pyqbdi_readMemory,           METH_VARARGS,  "Read a memory content from a base address."},
         {"simulateCall",         (PyCFunction)pyqbdi_simulateCall,         METH_VARARGS,  "Simulate a call by modifying the stack and registers accordingly."},
         {"writeMemory",          (PyCFunction)pyqbdi_writeMemory,          METH_VARARGS,  "Write a memory content to a base address."},


### PR DESCRIPTION
Should solve the issue #36.
I didn't documented getRemoteProcessMaps as it's not really a public API...

Documentation has been improved, but :

- CPP API doc rendering is broken with the latest version of Sphinx and breathe
- pyQBDI documentation could really still be improved