### PR TITLE
Fix of Register class not found

### DIFF
--- a/src/ExecBlock/ExecBlockManager.cpp
+++ b/src/ExecBlock/ExecBlockManager.cpp
@@ -310,7 +310,7 @@ void ExecBlockManager::updateRegionStat(size_t r, rword translated) {
     unsigned reserved = (unsigned) (((float) (regions[r].covered.size() - regions[r].translated)) * getExpansionRatio());
     LogDebug(
         "ExecBlockManager::updateRegionStat", 
-        "Region %zu has %zu bytes available of which %zu are reserved for %zu bytes of untranslated code",
+        "Region %zu has %zu bytes available of which %u are reserved for %zu bytes of untranslated code",
         r,
         regions[r].available,
         reserved,

--- a/src/Patch/PatchUtils.h
+++ b/src/Patch/PatchUtils.h
@@ -162,11 +162,11 @@ public:
     unsigned getRegSize(unsigned reg) {
         for(unsigned i = 0; i < MRI->getNumRegClasses(); i++) {
             if(MRI->getRegClass(i).contains(reg)) {
-                return MRI->getRegClass(i).getSize();
+                return MRI->getRegClass(i).getPhysRegSize();
             }
         }
-        LogError("TempManager::getRegSize", "Register class not found");
-        abort();
+        LogError("TempManager::getRegSize", "Register class for register %u not found", reg);
+        return 0;
     }
 
     unsigned getSizedSubReg(unsigned reg, unsigned size) {
@@ -175,7 +175,7 @@ public:
         }
         for(unsigned i = 1; i < MRI->getNumSubRegIndices(); i++) {
             unsigned subreg = MRI->getSubReg(reg, i);
-            if(getRegSize(subreg) == size) {
+            if(subreg != 0 && getRegSize(subreg) == size) {
                 return subreg;
             }
         }


### PR DESCRIPTION
I don't know why, I don't know when, but sometimes `getSubReg` did return 0 causing issue #46.
It seems that ignoring those value do fix the issue.

There is also an unrelated and boring fix of an integer formatting under macOS bundled in there.