### PR TITLE
validator: Make Process an abstract base class

### DIFF
--- a/tools/validator/process.h
+++ b/tools/validator/process.h
@@ -26,21 +26,21 @@ class Process {
 
 public:
 
-    virtual ~Process() {}
+    virtual ~Process() = default;
 
-    virtual pid_t getPID();
+    virtual pid_t getPID() = 0;
 
-    virtual void setBreakpoint(void* address);
+    virtual void setBreakpoint(void* address) = 0;
 
-    virtual void unsetBreakpoint();
+    virtual void unsetBreakpoint() = 0;
 
-    virtual void continueExecution();
+    virtual void continueExecution() = 0;
 
-    virtual int waitForStatus();
+    virtual int waitForStatus() = 0;
 
-    virtual void getProcessGPR(QBDI::GPRState *gprState);
+    virtual void getProcessGPR(QBDI::GPRState *gprState) = 0;
     
-    virtual void getProcessFPR(QBDI::FPRState *fprState);
+    virtual void getProcessFPR(QBDI::FPRState *fprState) = 0;
 };
 
 bool hasExited(int status);


### PR DESCRIPTION
When building without optimisation, this class generates a linker error since no vtable is present for it. This is due to the fact that none of the functions specified in the interface is actually implemented. Looking at how the class is used, I deduced that it was meant to be an abstract base class, but the methods were only declared as virtual instead of pure virtual.